### PR TITLE
Implementing new StopProcessRequest and VMHealth Check endpoint.

### DIFF
--- a/CadServices.sln
+++ b/CadServices.sln
@@ -163,8 +163,10 @@ Global
 		submodules\BDotNetFramework\Services\BServiceUtilities-FileService-AZ\BServiceUtilities-FileService-AZ.projitems*{bfae34cb-8c34-4a80-8ae2-45ed63aeb427}*SharedItemsImports = 5
 		submodules\BDotNetFramework\Services\BServiceUtilities-MemoryService-Redis\BServiceUtilities-MemoryService-Redis.projitems*{bfae34cb-8c34-4a80-8ae2-45ed63aeb427}*SharedItemsImports = 5
 		submodules\BDotNetFramework\Services\BServiceUtilities-PubSubService-AZ\BServiceUtilities-PubSubService-AZ.projitems*{bfae34cb-8c34-4a80-8ae2-45ed63aeb427}*SharedItemsImports = 5
+		submodules\BDotNetFramework\Services\BServiceUtilities-VMService-AZ\BServiceUtilities-VMService-AZ.projitems*{bfae34cb-8c34-4a80-8ae2-45ed63aeb427}*SharedItemsImports = 5
 		submodules\BDotNetFramework\Services\BServiceUtilities\BServiceUtilities.projitems*{bfae34cb-8c34-4a80-8ae2-45ed63aeb427}*SharedItemsImports = 5
 		submodules\BDotNetFramework\Utilities\ServiceUtilities_All\ServiceUtilities_All.projitems*{bfae34cb-8c34-4a80-8ae2-45ed63aeb427}*SharedItemsImports = 5
+		submodules\BDotNetFramework\Utilities\ServiceUtilities_PubSub_DB_Users\ServiceUtilities_PubSub_DB_Users.projitems*{bfae34cb-8c34-4a80-8ae2-45ed63aeb427}*SharedItemsImports = 5
 		submodules\BDotNetFramework\Utilities\ServiceUtilities_PubSub_Users\ServiceUtilities_PubSub_Users.projitems*{bfae34cb-8c34-4a80-8ae2-45ed63aeb427}*SharedItemsImports = 5
 		submodules\BFilesdk-Dotnet\common\BFileSDK-Dotnet\BFileSDK-Dotnet.projitems*{bfae34cb-8c34-4a80-8ae2-45ed63aeb427}*SharedItemsImports = 5
 		submodules\BDotNetFramework\Services\BServiceUtilities-FileService-GC\BServiceUtilities-FileService-GC.projitems*{c7d560ac-a66b-44e9-8634-26543a8ead2d}*SharedItemsImports = 13

--- a/services/CADFileService/Endpoints/Common/CommonMethods.cs
+++ b/services/CADFileService/Endpoints/Common/CommonMethods.cs
@@ -16,78 +16,12 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Convert = ServiceUtilities.Process.Convert;
 using StreamReader = System.IO.StreamReader;
-using ServiceUtilities_All.Common;
+using ServiceUtilities.Common;
 
 namespace CADFileService.Endpoints.Common
 {
     public class CommonMethods
     {
-        public enum EGetClearance
-        {
-            Yes,
-            No
-        }
-        public static bool GenerateNonExistentUniqueID(
-            WebServiceBaseTimeoutable _Request,
-            IBDatabaseServiceInterface _DatabaseService,
-            string _TableName,
-            string _TableKeyName,
-            string[] _TableEntryMustHaveProperties,
-            EGetClearance _GetClearance,
-            out string _GeneratedUniqueID, 
-            out BWebServiceResponse _FailureResponse,
-            Action<string> _ErrorMessageAction = null)
-        {
-            _GeneratedUniqueID = null;
-            _FailureResponse = BWebResponse.InternalError("");
-
-            int ExistenceTrial = 0;
-
-            while (_GeneratedUniqueID == null && ExistenceTrial < 3)
-            {
-                if (!BUtility.CalculateStringMD5(BUtility.RandomString(32, false), out _GeneratedUniqueID, _ErrorMessageAction))
-                {
-                    _FailureResponse = BWebResponse.InternalError("Hashing operation has failed.");
-                    return false;
-                }
-
-                if (_GetClearance == EGetClearance.Yes && !Controller_AtomicDBOperation.Get().GetClearanceForDBOperation(_Request.InnerProcessor, _TableName, _GeneratedUniqueID, _ErrorMessageAction))
-                {
-                    _FailureResponse = BWebResponse.InternalError("Atomic operation control has failed.");
-                    return false;
-                }
-
-                if (!_DatabaseService.GetItem(
-                    _TableName,
-                    _TableKeyName,
-                    new BPrimitiveType(_GeneratedUniqueID),
-                    _TableEntryMustHaveProperties,
-                    out JObject ExistenceCheck,
-                    _ErrorMessageAction))
-                {
-                    _FailureResponse = BWebResponse.InternalError("Database existence check operation has failed.");
-                    return false;
-                }
-                if (ExistenceCheck != null)
-                {
-                    if (_GetClearance == EGetClearance.Yes)
-                    {
-                        Controller_AtomicDBOperation.Get().SetClearanceForDBOperationForOthers(_Request.InnerProcessor, _TableName, _GeneratedUniqueID, _ErrorMessageAction);
-                    }
-                    
-                    _GeneratedUniqueID = null;
-                    ExistenceTrial++;
-                }
-                else break;
-            }
-            if (_GeneratedUniqueID == null)
-            {
-                _FailureResponse = BWebResponse.InternalError("Unique model ID generation operation has failed.");
-                return false;
-            }
-            return true;
-        }
-
         public static string GetTimeAsCreationTime()
         {
             return DateTime.UtcNow.ToLongDateString() + " - " + DateTime.UtcNow.ToLongTimeString();

--- a/services/CADFileService/Endpoints/Model_AddListModels.cs
+++ b/services/CADFileService/Endpoints/Model_AddListModels.cs
@@ -13,6 +13,7 @@ using ServiceUtilities;
 using ServiceUtilities.PubSubUsers.PubSubRelated;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using ServiceUtilities.Common;
 
 namespace CADFileService
 {
@@ -68,10 +69,10 @@ namespace CADFileService
             }
             NewModelObject.ModelOwnerUserID = AuthorizedUser.UserID;
 
-            if (!CommonMethods.GenerateNonExistentUniqueID(
+            if (!Methods.GenerateNonExistentUniqueID(
                 this, 
                 DatabaseService, ModelDBEntry.DBSERVICE_MODELS_TABLE(), ModelDBEntry.KEY_NAME_MODEL_ID, ModelDBEntry.MustHaveProperties,
-                CommonMethods.EGetClearance.Yes,
+                EGetClearance.Yes,
                 out string ModelID,
                 out BWebServiceResponse _FailureResponse,
                 _ErrorMessageAction))

--- a/services/CADFileService/Endpoints/Model_GetUpdateDeleteRaw_ForRevision.cs
+++ b/services/CADFileService/Endpoints/Model_GetUpdateDeleteRaw_ForRevision.cs
@@ -13,7 +13,7 @@ using ServiceUtilities;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using ServiceUtilities.PubSubUsers.PubSubRelated;
-using ServiceUtilities_All.Common;
+using ServiceUtilities.Common;
 
 namespace CADFileService
 {

--- a/services/CADFileService/Endpoints/Structures/FileEntry.cs
+++ b/services/CADFileService/Endpoints/Structures/FileEntry.cs
@@ -2,12 +2,12 @@
 
 using System;
 using System.Collections.Generic;
-using ServiceUtilities;
-using ServiceUtilities_All.Common;
+using System.Net;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using System.Net;
 using CADFileService.Endpoints.Common;
+using ServiceUtilities;
+using ServiceUtilities.Common;
 
 namespace CADFileService.Endpoints.Structures
 {

--- a/services/CADProcessService/CADProcessService.csproj
+++ b/services/CADProcessService/CADProcessService.csproj
@@ -29,6 +29,7 @@
     <ProjectReference Include="..\..\submodules\BDotNetFramework\Utilities\BCloudServiceUtilities-BLoggingService-Basic\BCloudServiceUtilities-BLoggingService-Basic.csproj" />
     <ProjectReference Include="..\..\submodules\BDotNetFramework\Utilities\BCloudServiceUtilities-BMemoryService-Redis\BCloudServiceUtilities-BMemoryService-Redis.csproj" />
     <ProjectReference Include="..\..\submodules\BDotNetFramework\Utilities\BCloudServiceUtilities-BPubSubService-AZ\BCloudServiceUtilities-BPubSubService-AZ.csproj" />
+    <ProjectReference Include="..\..\submodules\BDotNetFramework\Utilities\BCloudServiceUtilities-BVMService-AZ\BCloudServiceUtilities-BVMService-AZ.csproj" />
     <ProjectReference Include="..\..\submodules\BDotNetFramework\Utilities\BCloudServiceUtilities\BCloudServiceUtilities.csproj" />
     <ProjectReference Include="..\..\submodules\BDotNetFramework\Utilities\BCommonUtilities\BCommonUtilities.csproj" />
     <ProjectReference Include="..\..\submodules\BDotNetFramework\Utilities\BWebServiceUtilities-Basic\BWebServiceUtilities-Basic.csproj" />
@@ -50,5 +51,9 @@
   <Import Project="..\..\submodules\BDotNetFramework\Services\BServiceUtilities-DatabaseService-MongoDB\BServiceUtilities-DatabaseService-MongoDB.projitems" Label="Shared" />
 
   <Import Project="..\..\submodules\BDotNetFramework\Services\BServiceUtilities-PubSubService-AZ\BServiceUtilities-PubSubService-AZ.projitems" Label="Shared" />
+
+  <Import Project="..\..\submodules\BDotNetFramework\Services\BServiceUtilities-VMService-AZ\BServiceUtilities-VMService-AZ.projitems" Label="Shared" />
+
+  <Import Project="..\..\submodules\BDotNetFramework\Utilities\ServiceUtilities_PubSub_DB_Users\ServiceUtilities_PubSub_DB_Users.projitems" Label="Shared" />
 
 </Project>

--- a/services/CADProcessService/Endpoints/StopProcessRequest.cs
+++ b/services/CADProcessService/Endpoints/StopProcessRequest.cs
@@ -1,39 +1,49 @@
 ﻿/// MIT License, Copyright Burak Kara, burak@burak.io, https://en.wikipedia.org/wiki/MIT_License
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Net;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json;
 using BCloudServiceUtilities;
 using BCommonUtilities;
 using BWebServiceUtilities;
 using CADProcessService.Endpoints.Structures;
 using CADProcessService.K8S;
-using ServiceUtilities.All;
-using Newtonsoft.Json.Linq;
+using ServiceUtilities;
+using ServiceUtilities.Common;
+using CADProcessService.Endpoints.Controllers;
 
 namespace CADProcessService.Endpoints
 {
-    internal class StopProcessRequest : BppWebServiceBase
+    internal class StopProcessRequest : WebServiceBaseTimeoutable
     {
         private readonly IBDatabaseServiceInterface DatabaseService;
 
-        public StopProcessRequest(IBDatabaseServiceInterface _DatabaseService) : base()
+        private readonly IBVMServiceInterface VirtualMachineService;
+
+        private readonly Dictionary<string, string> VirtualMachineDictionary;
+
+        public StopProcessRequest(IBDatabaseServiceInterface _DatabaseService, IBVMServiceInterface _VirtualMachineService, Dictionary<string, string> _VirtualMachineDictionary) : base()
         {
             DatabaseService = _DatabaseService;
+            VirtualMachineService = _VirtualMachineService;
+            VirtualMachineDictionary = _VirtualMachineDictionary;
         }
 
-        protected override BWebServiceResponse OnRequestPP(HttpListenerContext _Context, Action<string> _ErrorMessageAction = null)
+        public override BWebServiceResponse OnRequest_Interruptable(HttpListenerContext _Context, Action<string> _ErrorMessageAction = null)
         {
             GetTracingService()?.On_FromServiceToService_Received(_Context, _ErrorMessageAction);
 
-            var Result = OnRequest_Internal(_Context, _ErrorMessageAction);
+            var Result = OnRequest_Interruptable_Internal(_Context, _ErrorMessageAction);
 
             GetTracingService()?.On_FromServiceToService_Sent(_Context, _ErrorMessageAction);
 
             return Result;
         }
 
-        private BWebServiceResponse OnRequest_Internal(HttpListenerContext _Context, Action<string> _ErrorMessageAction)
+        private BWebServiceResponse OnRequest_Interruptable_Internal(HttpListenerContext _Context, Action<string> _ErrorMessageAction)
         {
             if (_Context.Request.HttpMethod != "POST")
             {
@@ -42,8 +52,10 @@ namespace CADProcessService.Endpoints
             }
 
             string BucketName = null;
-            string RelativeFilename = null;
+            string RelativeFileUrl = null;
             string ConversionID_FromRelativeUrl_UrlEncoded = null;
+            int ProcessMode = (int)EProcessMode.Undefined;
+            string RequestedVirtualMachineId = null;
 
             using (var InputStream = _Context.Request.InputStream)
             {
@@ -55,21 +67,53 @@ namespace CADProcessService.Endpoints
                     {
                         var ParsedBody = JObject.Parse(ResponseReader.ReadToEnd());
 
-                        if (!ParsedBody.ContainsKey("bucketName") ||
-                            !ParsedBody.ContainsKey("rawFileRelativeUrl"))
+                        if (!ParsedBody.ContainsKey("processMode"))
                         {
                             return BWebResponse.BadRequest("Request body must contain all necessary fields.");
                         }
-                        var BucketNameToken = ParsedBody["bucketName"];
-                        var RawFileRelativeUrlToken = ParsedBody["rawFileRelativeUrl"];
-                        if (BucketNameToken.Type != JTokenType.String ||
-                            RawFileRelativeUrlToken.Type != JTokenType.String)
+                        var ProcessModeToken = ParsedBody["processMode"];
+                        if (ProcessModeToken.Type != JTokenType.Integer)
                         {
                             return BWebResponse.BadRequest("Request body contains invalid fields.");
                         }
-                        BucketName = (string)BucketNameToken;
-                        ConversionID_FromRelativeUrl_UrlEncoded = WebUtility.UrlEncode((string)RawFileRelativeUrlToken);
-                        RelativeFilename = (string)RawFileRelativeUrlToken;
+                        ProcessMode = (int)ProcessModeToken;
+
+                        if (ProcessMode == (int)EProcessMode.Kubernetes)
+                        {
+                            if (!ParsedBody.ContainsKey("bucketName")
+                                || !ParsedBody.ContainsKey("rawFileRelativeUrl"))
+                            {
+                                return BWebResponse.BadRequest("Request body must contain all necessary fields. If the process mode is selected Kubernetes, request body has to have rawFileRelativeUrl and bucketName fields.");
+                            }
+
+                            var BucketNameToken = ParsedBody["bucketName"];
+                            var RawFileRelativeUrlToken = ParsedBody["rawFileRelativeUrl"];
+                            if (BucketNameToken.Type != JTokenType.String
+                                || RawFileRelativeUrlToken.Type != JTokenType.String)
+                            {
+                                return BWebResponse.BadRequest("Request body contains invalid fields.");
+                            }
+                        
+                            BucketName = (string)BucketNameToken;
+                            RelativeFileUrl = (string)RawFileRelativeUrlToken;
+                            ConversionID_FromRelativeUrl_UrlEncoded = WebUtility.UrlEncode((string)RawFileRelativeUrlToken);
+                        }
+
+                        if (ProcessMode == (int)EProcessMode.VirtualMachine)
+                        { 
+                            if (!ParsedBody.ContainsKey("virtualMachineId"))
+                            {
+                                return BWebResponse.BadRequest("Request body must contain all necessary fields. If the process mode is selected VirtualMachine, request body has to have virtualMachineId field.");
+                            }
+
+                            var RequestedVirtualMachineIdToken = ParsedBody["virtualMachineId"];
+                            if (RequestedVirtualMachineIdToken.Type != JTokenType.String)
+                            {
+                                return BWebResponse.BadRequest("Request body contains invalid fields.");
+                            }
+
+                            RequestedVirtualMachineId = (string)RequestedVirtualMachineIdToken;   
+                        }
                     }
                     catch (Exception e)
                     {
@@ -78,6 +122,37 @@ namespace CADProcessService.Endpoints
                     }
                 }
             }
+
+            if (ProcessMode == (int)EProcessMode.Kubernetes)
+            {
+                if (!ProcessKubernetes(ConversionID_FromRelativeUrl_UrlEncoded, BucketName, RelativeFileUrl, _ErrorMessageAction, out BWebServiceResponse FailureResponse))
+                {
+                    return FailureResponse;
+                }
+            }
+            else if (ProcessMode == (int)EProcessMode.VirtualMachine)
+            {
+                if (!ProcessVirtualMachine(_Context, RequestedVirtualMachineId, _ErrorMessageAction, out BWebServiceResponse FailureResponse))
+                {
+                    return FailureResponse;
+                }
+            }
+            else
+            {
+                return BWebResponse.BadRequest("Undefined process mode selected. Please check the process mode that you select.");
+            }
+
+            return BWebResponse.StatusAccepted("Request has been accepted; process is now being stopped.");
+        }
+
+        private bool ProcessKubernetes(
+            string ConversionID_FromRelativeUrl_UrlEncoded,
+            string BucketName,
+            string RelativeFileUrl,
+            Action<string> _ErrorMessageAction,
+            out BWebServiceResponse _FailureResponse)
+        {
+            _FailureResponse = BWebResponse.InternalError("");
 
             //Temporarily, TODO: Change this when the implementation is in place.
             if (!DatabaseService.DeleteItem(
@@ -96,16 +171,164 @@ namespace CADProcessService.Endpoints
                     _ErrorMessageAction)
                     || _ReturnObject != null)
                 {
-                    return BWebResponse.InternalError("Database error.");
+                    _FailureResponse = BWebResponse.InternalError("Database error.");
+                    return false;
                 }
             }
 
-            if(!BatchProcessingCreationService.Instance.StopBatchProcess(BucketName, RelativeFilename, _ErrorMessageAction))
+            if (!BatchProcessingCreationService.Instance.StopBatchProcess(BucketName, RelativeFileUrl, _ErrorMessageAction))
             {
-                return BWebResponse.InternalError("Failed to stop pod or connect to kubernetess");
+                _FailureResponse = BWebResponse.InternalError("Failed to stop pod or connect to kubernetess");
+                return false;
             }
 
-            return BWebResponse.StatusAccepted("Request has been accepted; process is now being stopped.");
+            return true;
+        }
+
+        private bool ProcessVirtualMachine(
+            HttpListenerContext _Context,
+            string _RequestedVirtualMachineId,
+            Action<string> _ErrorMessageAction,
+            out BWebServiceResponse FailureResponse)
+        {
+            FailureResponse = BWebResponse.InternalError("");
+
+            if (!DatabaseService.GetItem(
+                WorkerVMListDBEntry.DBSERVICE_WORKERS_VM_LIST_TABLE(),
+                WorkerVMListDBEntry.KEY_NAME_VM_UNIQUE_ID,
+                new BPrimitiveType(_RequestedVirtualMachineId),
+                WorkerVMListDBEntry.Properties,
+                out JObject _ReturnObject, _ErrorMessageAction
+                ) || _ReturnObject == null)
+            {
+                FailureResponse = BWebResponse.InternalError("Database error.");
+                return false;
+            }
+
+            WorkerVMListDBEntry VirtualMachineEntry = _ReturnObject.ToObject<WorkerVMListDBEntry>();
+
+            if (VirtualMachineEntry != null)
+            {
+                string VirtualMachineName = VirtualMachineDictionary[_RequestedVirtualMachineId];
+
+                if (!VirtualMachineService.StopInstances(new string[] { VirtualMachineName },
+                    () =>
+                    {
+                        if (!UpdateDBVirtualMachineAvailability(_RequestedVirtualMachineId, _ErrorMessageAction, VirtualMachineName, VirtualMachineEntry))
+                        {
+                            _ErrorMessageAction?.Invoke($"Failed to update worker-vm-list database for virtual machine [{VirtualMachineName}]");
+                        }
+
+                        if (!UpdateDBProcessHistory(_Context, VirtualMachineEntry, _ErrorMessageAction))
+                        {
+                            _ErrorMessageAction?.Invoke($"Failed to update process-history database for virtual machine [{VirtualMachineName}]");
+                        }
+
+                        Controller_BatchProcess.Get().BroadcastBatchProcessAction(new Action_BatchProcessFailed()
+                        {
+                            ModelName = VirtualMachineEntry.ModelName,
+                            RevisionIndex = VirtualMachineEntry.RevisionIndex
+                        },_ErrorMessageAction);
+                    },
+                    () =>
+                    {
+                        _ErrorMessageAction?.Invoke($"Failed to stop virtual machine [{VirtualMachineName}]");
+                    }, _ErrorMessageAction))
+                {
+                    FailureResponse = BWebResponse.InternalError($"Failed to stop virtual machine [{VirtualMachineName}]");
+                    return false;
+                }
+            }
+            else
+            {
+                FailureResponse = BWebResponse.InternalError("Database object is empty.");
+                return false;
+            }
+
+            return true;
+        }
+
+        private bool UpdateDBVirtualMachineAvailability(
+            string _RequestedVirtualMachineId,
+            Action<string> _ErrorMessageAction,
+            string VirtualMachineName,
+            WorkerVMListDBEntry _VirtualMachineEntry)
+        {
+            try
+            {
+                if (!Controller_AtomicDBOperation.Get().GetClearanceForDBOperation(InnerProcessor, WorkerVMListDBEntry.DBSERVICE_WORKERS_VM_LIST_TABLE(), _RequestedVirtualMachineId, _ErrorMessageAction))
+                {
+                    _ErrorMessageAction?.Invoke($"Failed to update db for [{VirtualMachineName}] because atomic db operation has been failed.");
+                    return false;
+                }
+                _VirtualMachineEntry.VMStatus = (int)EVMStatus.Available;
+
+                if (!DatabaseService.UpdateItem(
+                WorkerVMListDBEntry.DBSERVICE_WORKERS_VM_LIST_TABLE(),
+                WorkerVMListDBEntry.KEY_NAME_VM_UNIQUE_ID,
+                new BPrimitiveType(_RequestedVirtualMachineId),
+                JObject.Parse(JsonConvert.SerializeObject(_VirtualMachineEntry)),
+                out JObject _, EBReturnItemBehaviour.DoNotReturn,
+                DatabaseService.BuildAttributeNotExistCondition(WorkerVMListDBEntry.KEY_NAME_VM_UNIQUE_ID),
+                _ErrorMessageAction))
+                {
+                    _ErrorMessageAction?.Invoke($"Failed to update worker-vm-list table for [{VirtualMachineName}]");
+                    return false;
+                }
+            }
+            catch (System.Exception ex)
+            {
+                _ErrorMessageAction?.Invoke($"Failed to update worker-vm-list table for [{VirtualMachineName}]. Error: {ex.Message}. Trace: {ex.StackTrace}");
+                return false;
+            }
+            finally
+            {
+                Controller_AtomicDBOperation.Get().SetClearanceForDBOperationForOthers(InnerProcessor, WorkerVMListDBEntry.DBSERVICE_WORKERS_VM_LIST_TABLE(), _RequestedVirtualMachineId, _ErrorMessageAction);
+            }
+            return true;
+        }
+
+        private bool UpdateDBProcessHistory(
+            HttpListenerContext _Context,
+            WorkerVMListDBEntry _VirtualMachineEntry,
+            Action<string> _ErrorMessageAction)
+        {
+            try
+            {
+                if (!Methods.GenerateNonExistentUniqueID(this, DatabaseService, 
+                    ProcessHistoryDBEntry.DBSERVICE_PROCESS_HISTORY_TABLE(),
+                    ProcessHistoryDBEntry.KEY_NAME_PROCESS_ID,
+                    ProcessHistoryDBEntry.MustHaveProperties,
+                    EGetClearance.Yes,
+                    out string ProcessID,
+                    out BWebServiceResponse _,
+                    _ErrorMessageAction))
+                {
+                    _ErrorMessageAction?.Invoke("Failed to generate non-existent unique id for process-history table.");
+                    return false;
+                }
+
+                var NewProcessHistoryObject = new JObject() { 
+                    [ProcessHistoryDBEntry.MODEL_UNIQUE_NAME_PROPERTY] = _VirtualMachineEntry.ModelName,
+                    [ProcessHistoryDBEntry.MODEL_REVISION_INDEX_PROPERTY] = _VirtualMachineEntry.RevisionIndex,
+                    [ProcessHistoryDBEntry.CURRENT_PROCESS_STAGE_PROPERTY] = _VirtualMachineEntry.CurrentProcessStage,
+                    [ProcessHistoryDBEntry.HISTORY_RECORD_DATE_PROPERTY] = Methods.GetNowAsLongDateAndTimeString(),
+                    [ProcessHistoryDBEntry.PROCESS_STATUS_PROPERTY] = (int)EProcessStatus.Canceled,
+                    [ProcessHistoryDBEntry.PROCESS_INFO_PROPERTY] = "Stop process has been called."
+                };
+                Controller_DeliveryEnsurer.Get().DB_PutItem_FireAndForget(
+                    _Context,
+                    ProcessHistoryDBEntry.DBSERVICE_PROCESS_HISTORY_TABLE(),
+                    ProcessHistoryDBEntry.KEY_NAME_PROCESS_ID,
+                    new BPrimitiveType(ProcessID),
+                    JObject.Parse(JsonConvert.SerializeObject(NewProcessHistoryObject)));
+            }
+            catch (System.Exception ex)
+            {
+                _ErrorMessageAction?.Invoke($"Failed to add process-history record. Error: {ex.Message}. Trace: {ex.StackTrace}");
+                return false;
+            }
+            return true;
         }
     }
 }

--- a/services/CADProcessService/Endpoints/Structures/ProcessHistoryDBEntry.cs
+++ b/services/CADProcessService/Endpoints/Structures/ProcessHistoryDBEntry.cs
@@ -3,7 +3,7 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using ServiceUtilities;
-using ServiceUtilities_All.Common;
+using ServiceUtilities.Common;
 using System;
 
 namespace CADProcessService.Endpoints.Structures
@@ -54,7 +54,7 @@ namespace CADProcessService.Endpoints.Structures
         public int ProcessStatus = (int)EProcessStatus.Idle;
 
         [JsonProperty(HISTORY_RECORD_DATE_PROPERTY)]
-        public DateTime HistoryRecordDate { get; set; }
+        public string HistoryRecordDate = Methods.GetNowAsLongDateAndTimeString();
 
         [JsonProperty(CURRENT_PROCESS_STAGE_PROPERTY)]
         public int CurrentProcessStage = (int)EProcessStage.Stage0_FileUpload;

--- a/services/CADProcessService/Endpoints/Structures/WorkerVMListDBEntry.cs
+++ b/services/CADProcessService/Endpoints/Structures/WorkerVMListDBEntry.cs
@@ -1,11 +1,11 @@
 ﻿/// MIT License, Copyright Burak Kara, burak@burak.io, https://en.wikipedia.org/wiki/MIT_License
 
+using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using ServiceUtilities;
-using ServiceUtilities_All.Common;
-using System;
-using System.Collections.Generic;
+using ServiceUtilities.Common;
 
 namespace CADProcessService.Endpoints.Structures
 {
@@ -55,7 +55,7 @@ namespace CADProcessService.Endpoints.Structures
         public int VMStatus = (int)EVMStatus.Available;
 
         [JsonProperty(PROCESS_START_DATE_PROPERTY)]
-        public DateTime ProcessStartDate { get; set; }
+        public string ProcessStartDate = Methods.GetNowAsLongDateAndTimeString();
 
         [JsonProperty(MODEL_UNIQUE_NAME_PROPERTY)]
         public string ModelName { get; set; }
@@ -64,7 +64,7 @@ namespace CADProcessService.Endpoints.Structures
         public int RevisionIndex { get; set; }
 
         [JsonProperty(STAGE_PROCESS_START_DATES_PROPERTY)]
-        public List<DateTime> StageProcessStartDates = new List<DateTime>();
+        public List<string> StageProcessStartDates = new List<string>();
 
         [JsonProperty(CURRENT_PROCESS_STAGE_PROPERTY)]
         public int CurrentProcessStage = (int)EProcessStage.Stage0_FileUpload;

--- a/services/CADProcessService/Endpoints/VMHealthCheck.cs
+++ b/services/CADProcessService/Endpoints/VMHealthCheck.cs
@@ -1,0 +1,30 @@
+﻿/// MIT License, Copyright Burak Kara, burak@burak.io, https://en.wikipedia.org/wiki/MIT_License
+
+using System;
+using System.Net;
+using BWebServiceUtilities;
+using ServiceUtilities;
+
+namespace CADProcessService.Endpoints
+{
+    partial class InternalCalls
+    {
+        internal class VMHealthCheck : InternalWebServiceBaseTimeoutable
+        {
+            public VMHealthCheck(string _InternalCallPrivateKey) : base(_InternalCallPrivateKey)
+            {
+            }
+
+            public override BWebServiceResponse OnRequest_Interruptable(HttpListenerContext _Context, Action<string> _ErrorMessageAction = null)
+            {
+                if (_Context.Request.HttpMethod != "GET")
+                {
+                    _ErrorMessageAction?.Invoke("VMHealthCheck: GET method is accepted. But received request method:  " + _Context.Request.HttpMethod);
+                    return BWebResponse.MethodNotAllowed("GET method is accepted. But received request method: " + _Context.Request.HttpMethod);
+                }
+
+                return BWebResponse.StatusOK("VM Health check has successfully been completed.");
+            }
+        }
+    }
+}

--- a/services/CADProcessService/K8S/BatchProcessingCreationService.cs
+++ b/services/CADProcessService/K8S/BatchProcessingCreationService.cs
@@ -432,7 +432,7 @@ namespace CADProcessService.K8S
 
         private static bool GetModelDetailsFromFilePath(
             string _Filename, 
-            out string _ModelId, 
+            out string _ModelName, 
             out int _RevisionIndex, 
             Action<string> _ErrorMessageAction = null)
         {
@@ -440,14 +440,14 @@ namespace CADProcessService.K8S
             {
                 //Expecting format raw/b7192e4a29de7c3be8f1fbdd12913886/0/0/file.zip"
                 string[] Parts = _Filename.Split('/');
-                _ModelId = Parts[1];
+                _ModelName = Parts[1];
                 _RevisionIndex = int.Parse(Parts[2]);
                 return true;
             }
             catch (Exception ex)
             {
                 _ErrorMessageAction?.Invoke($"Failed to extract model info from [{_Filename}] - {ex.Message}\n{ex.StackTrace}");
-                _ModelId = null;
+                _ModelName = null;
                 _RevisionIndex = -1;
                 return false;
             }
@@ -484,12 +484,12 @@ namespace CADProcessService.K8S
                     }
                 }
 
-                if (GetModelDetailsFromFilePath(Filename, out string _ModelId, out int _RevisionIndex, _ErrorMessageAction))
+                if (GetModelDetailsFromFilePath(Filename, out string _ModelName, out int _RevisionIndex, _ErrorMessageAction))
                 {
                     //if we fail then you have a broken model on a broken path
                     Controller_BatchProcess.Get().BroadcastBatchProcessAction(new Action_BatchProcessFailed()
                     {
-                        ModelID = _ModelId,
+                        ModelName = _ModelName,
                         RevisionIndex = _RevisionIndex
                     },
                     _ErrorMessageAction);


### PR DESCRIPTION
UPDATED StopProcessRequest as compatible with VirtualMachine stopping operations.

ADDED VMHealthCheck endpoints for scheduler calls as an internal endpoint.
UPDATED FileEntry with new ServiceUtilities.Common namespace instead of ServiceUtilities_All usage.
MOVED GenerateNonExistentUniqueID from CADFileService Common to ServiceUtilities.Common Methods.cs
MOVED EGetClearance enum to ServiceUtilities.Common Enums.cs
ADDED TryGettingModelID step after changing Action_BatchProcessFailed ModelID to ModelName
UPDATED ProcessHistory and WorkerVMList tables DateTime usage that is changed with string.
ADDED INTERNAL_CALL_PRIVATE_KEY as an environment variable to CAD Process service.